### PR TITLE
Align open_fdinfo_dir with pidfds_to_pids

### DIFF
--- a/common/common-pidfds.c
+++ b/common/common-pidfds.c
@@ -196,12 +196,5 @@ int pidfds_to_pids(int *fds, pid_t *pids, int count)
 /* misc directory helpers */
 int open_fdinfo_dir(void)
 {
-	int fd;
-
-	fd = open("/proc/self/fdinfo", O_RDONLY | O_NONBLOCK | O_DIRECTORY | O_CLOEXEC | O_NOCTTY);
-
-	if (fd == -1)
-		return errno;
-
-	return fd;
+	return open("/proc/self/fdinfo", O_RDONLY | O_NONBLOCK | O_DIRECTORY | O_CLOEXEC | O_NOCTTY);
 }


### PR DESCRIPTION
The function `pidfds_to_pids` expected `-1` if `open_fdinfo_dir` failed but the latter returned `errno` which is hard to distinguish from a valid file handle.  Correct that by making `open_fdinfo_dir` a wrapper around `open`.